### PR TITLE
feat(fed): add schema flag to envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: MOSAIC Integration Tests
         run: |
           docker pull paguos/nes-ui:v0.0.1
-          docker pull paguos/nes-executable:zmq_enabled
+          docker pull paguos/nes-mobility:0.0.1
           mvn test -fae -P integration-tests
   tool-scenario-generator:
     runs-on: ubuntu-latest

--- a/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/common/BooleanType.java
+++ b/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/common/BooleanType.java
@@ -12,6 +12,10 @@ public class BooleanType extends DataType {
         return 1;
     }
 
+    public static boolean parse(byte b) {
+        return b!=0;
+    }
+
     @Override
     public String parseString(byte[] bytes) {
         if (bytes[0] == 1) {

--- a/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/stream/BufferBuilder.java
+++ b/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/stream/BufferBuilder.java
@@ -18,6 +18,11 @@ public class BufferBuilder {
         return new BufferBuilder(bufferSize);
     }
 
+    public BufferBuilder fill(boolean bool) {
+        buffer[offset++] = (byte)(bool? 1:0);
+        return this;
+    }
+
     public BufferBuilder fill(byte aByte) {
         buffer[offset++] = aByte;
         return this;

--- a/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/stream/Envelope.java
+++ b/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/stream/Envelope.java
@@ -1,17 +1,25 @@
 package com.github.paguos.mosaic.fed.nebulastream.stream;
 
+import com.github.paguos.mosaic.fed.nebulastream.common.BasicType;
+import com.github.paguos.mosaic.fed.nebulastream.common.BooleanType;
 import com.github.paguos.mosaic.fed.nebulastream.common.IntegerType;
 
 import java.util.Arrays;
 
 public class Envelope {
 
+    private final boolean isSchema;
     private final long tuplesCount;
     private final long watermark;
 
-    public Envelope(long tuplesCount, long watermark) {
+    public Envelope(boolean isSchema, long tuplesCount, long watermark) {
+        this.isSchema = isSchema;
         this.tuplesCount = tuplesCount;
         this.watermark = watermark;
+    }
+
+    public boolean isSchema() {
+        return isSchema;
     }
 
     public long getTuplesCount() {
@@ -23,17 +31,29 @@ public class Envelope {
     }
 
     public byte[] toByteBuffer() {
-        return BufferBuilder.createBuffer(16)
+        return BufferBuilder.createBuffer(17)
+                .fill(isSchema)
                 .fill(tuplesCount)
                 .fill(watermark)
                 .build();
     }
 
     public static Envelope parse(byte[] bytes) {
+        int offset = 0;
+
+        BooleanType flagType = new BooleanType();
+        IntegerType dataType = new IntegerType(BasicType.UINT64);
+
+        boolean isSchema = BooleanType.parse(bytes[0]);
+        offset += flagType.getByteSize();
+
         long tuplesCount = IntegerType.parseLong(
-                Arrays.copyOfRange(bytes, 0, bytes.length / 2));
+                Arrays.copyOfRange(bytes, offset, offset + dataType.getByteSize()));
+
+        offset += dataType.getByteSize();
         long watermark = IntegerType.parseLong(
-                Arrays.copyOfRange(bytes, bytes.length / 2, bytes.length ));
-        return new Envelope(tuplesCount, watermark);
+                Arrays.copyOfRange(bytes, offset, offset + dataType.getByteSize()));
+
+        return new Envelope(isSchema, tuplesCount, watermark);
     }
 }

--- a/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/stream/zmq/ZeroMQSource.java
+++ b/fed/nes-federate/src/main/java/com/github/paguos/mosaic/fed/nebulastream/stream/zmq/ZeroMQSource.java
@@ -27,7 +27,7 @@ public class ZeroMQSource implements Runnable {
 
             while (running) {
                 if (!messages.isEmpty()) {
-                    Envelope envelope = new Envelope(1, 0);
+                    Envelope envelope = new Envelope(false, 1, 0);
                     socket.send(envelope.toByteBuffer());
                     socket.send(messages.poll());
                 }

--- a/fed/nes-federate/src/test/java/com/github/paguos/mosaic/fed/nebulastream/stream/EnvelopeTest.java
+++ b/fed/nes-federate/src/test/java/com/github/paguos/mosaic/fed/nebulastream/stream/EnvelopeTest.java
@@ -2,26 +2,43 @@ package com.github.paguos.mosaic.fed.nebulastream.stream;
 
 import org.junit.Test;
 
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class EnvelopeTest {
 
     @Test
-    public void envelopeToBytes() {
-        Envelope envelope = new Envelope(100, 2500);
+    public void payloadEnvelopeToBytes() {
+        Envelope envelope = new Envelope(false, 100, 2500);
 
-        byte[] expectedBytes = {100, 0, 0, 0, 0, 0, 0, 0, -60, 9, 0, 0, 0, 0, 0, 0};
+        byte[] expectedBytes = {0, 100, 0, 0, 0, 0, 0, 0, 0, -60, 9, 0, 0, 0, 0, 0, 0};
+        assertArrayEquals(expectedBytes, envelope.toByteBuffer());
+    }
+
+    @Test
+    public void metadataEnvelopeToBytes() {
+        Envelope envelope = new Envelope(true, 542, 0);
+
+        byte[] expectedBytes = {1, 30, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         assertArrayEquals(expectedBytes, envelope.toByteBuffer());
     }
 
     @Test
     public void parseFromBytes() {
-        byte[] bytes = {100, 0, 0, 0, 0, 0, 0, 0, -60, 9, 0, 0, 0, 0, 0, 0};
+        byte[] bytes = {0, 100, 0, 0, 0, 0, 0, 0, 0, -60, 9, 0, 0, 0, 0, 0, 0};
         Envelope envelope = Envelope.parse(bytes);
 
+        assertFalse(envelope.isSchema());
         assertEquals(100, envelope.getTuplesCount());
         assertEquals(2500, envelope.getWatermark());
+    }
+
+    @Test
+    public void parseSchemaEnvelope() {
+        byte[] bytes = {1, 30, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        Envelope envelope = Envelope.parse(bytes);
+
+        assertTrue(envelope.isSchema());
+        assertEquals(542, envelope.getTuplesCount());
+        assertEquals(0, envelope.getWatermark());
     }
 }

--- a/scenarios/barcelona/nes/nes_config.json
+++ b/scenarios/barcelona/nes/nes_config.json
@@ -1,6 +1,6 @@
 {
     "coordinator": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
     },
     "nodes": [
         {
@@ -18,6 +18,6 @@
         "reactPort": 3000
     },
     "worker": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
     }
 }

--- a/scenarios/ernst-reuter/nes/nes_config.json
+++ b/scenarios/ernst-reuter/nes/nes_config.json
@@ -1,6 +1,6 @@
 {
     "coordinator": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
     },
     "nodes": [
         {
@@ -18,6 +18,6 @@
         "reactPort": 3000
     },
     "worker": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
     }
 }

--- a/tools/scenario-generator/examples/configs/barcelona.json
+++ b/tools/scenario-generator/examples/configs/barcelona.json
@@ -33,7 +33,7 @@
     "nes": {
       "enabled": true,
       "coordinator": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
       },
       "ui": {
         "enabled": true,
@@ -41,7 +41,7 @@
         "reactPort": 3000
       },
       "worker": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
       },
       "nodes": [
         {

--- a/tools/scenario-generator/examples/configs/ernst-reuter.json
+++ b/tools/scenario-generator/examples/configs/ernst-reuter.json
@@ -33,7 +33,7 @@
     "nes": {
       "enabled": true,
       "coordinator": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
       },
       "ui": {
         "enabled": true,
@@ -41,7 +41,7 @@
         "reactPort": 3000
       },
       "worker": {
-        "image": "paguos/nes-executable:zmq_enabled"
+        "image": "paguos/nes-mobility:0.0.1"
       },
       "nodes": [
         {


### PR DESCRIPTION
- Add flag to the envelope in both `ZeroMQ` sink and source.
- The flag determines of the message contains schema metadata information.

Closes #71 